### PR TITLE
Fix Firefox z-sorting issues.

### DIFF
--- a/5/index.html
+++ b/5/index.html
@@ -11,6 +11,9 @@
         <div id=treewrapper>
           <img src=tree.png id=tree>
         </div>
+        <div id=track>
+          <img src=bg.png height=4000>
+        </div>
       </div>
     </div>
   </div>
@@ -22,7 +25,7 @@
 #viewport { width: 600px; height: 400px; overflow: hidden; background: url(back.png) repeat-x; background-size: auto 350px; perspective: 400px; }
 #camera { width: 0px; height: 0px; position: relative; left: 300px; top: 200px; transition: transform .4s; }
 #scenewrapper { width: 4000px; height: 4500px; transform-origin: 0 0; transition: transform .4s; }
-#scene { width: 4000px; height: 4000px; transform-origin: 0 0; background: url(bg.png) no-repeat; background-size: auto 4000px}
+#scene { width: 4000px; height: 4000px; transform-origin: 0 0;}
 #kartwrapper { position: absolute; transform-origin: center center; }
 #kart { width: 30px; transition: transform .4s, opacity .4s; opacity: 0; }
 #treewrapper { position: absolute; transform: translateX(1550px) translateY(550px) translateZ(40px); }


### PR DESCRIPTION
This PR addresses the Firefox glitching issues in [demo 5](https://github.com/xem/CSS3Dprototypes/tree/gh-pages/5).

Firefox's sorting of z-transformed elements is pretty awful. Creating a scene that renders correctly often relies on balancing transforms along the z axis with `z-index` and (in this case) DOM order. This "fix" moves the track into it's own element and places it after the other elements in the scene — in Firefox this will cause the track element to render underneath the other objects, preventing the glitching. If you move the element to the top of the scene you'll see the glitching again.

I've made the track an `<img>` element but there's no reason not to use a CSS background instead.

**Something else you should be aware of;** Firefox won't try to depth sort anything if there are more than 100 descendant elements in your 3D scene. Once you hit that magic number you'll have to sort the elements yourself by shifting them around in the DOM, which will kill performance. You can see this issue in my old [CSS lighting demo](http://keithclark.co.uk/articles/calculating-element-vertex-data-from-css-transforms/demo6/). Try using the DOM inspector to remove elements until the x-wing renders correctly.
